### PR TITLE
Added Requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,7 @@ python sc_decompress.py
 </pre>
 
 <h2>Installation</h2>
-<p>Install <code>Pillow</code> with:</p>
+<p>Install requirements with:</p>
 <pre>
-python -m pip install Pillow
-</pre>
-
-<p>Install <code>UrlLib3</code> with:</p>
-<pre>
-python -m pip install urllib3
+python install -r requirements.txt
 </pre>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+urllib3
+Pillow


### PR DESCRIPTION
Requirements.txt can be ran through pip install -r requirements.txt and is a better, more streamlined way to install python requirements. Also made change to README.md to reflect new instructions